### PR TITLE
Use Scotty as web framework for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,11 @@ jobs:
       run: |
         cabal v2-haddock
 
-    #- name: Tests
-    #  run: |
-    #    cabal v2-build --dependencies-only --enable-tests --enable-benchmarks --reorder-goals --max-backjumps=-1 --minimize-conflict-set --flags "EnableWebTests"
-    #    cabal v2-test --enable-tests --flags "EnableWebTests"
+    - name: Tests
+      run: |
+        cabal v2-build --dependencies-only --enable-tests --enable-benchmarks --reorder-goals --max-backjumps=-1 --minimize-conflict-set --flags "EnableWebTests"
+        cabal v2-install hspec-discover
+        cabal v2-test --enable-tests --flags "EnableWebTests"
 
     - name: Freeze dependencies
       shell: bash
@@ -120,16 +121,30 @@ jobs:
 
     - uses: actions/cache@v1
       name: Cache ~/.stack
+      if: runner.os != 'windows'
       with:
-        key: ${{ secrets.CI_CACHE_DATE }}-${{ runner.os }}-${{ matrix.lts }}-stack-${{ hashFiles('stack-*yaml.lock') }}-${{github.ref_name}}
+        key: ${{ secrets.CI_CACHE_DATE }}-${{ runner.os }}-${{ matrix.lts }}-stack-${{ hashFiles('stack-*yaml.lock') }}
         restore-keys: |
-          ${{ secrets.CI_CACHE_DATE }}-${{ runner.os }}-${{ matrix.lts }}-stack-${{ hashFiles('stack-*yaml.lock') }}
           ${{ secrets.CI_CACHE_DATE }}-${{ runner.os }}-${{ matrix.lts }}-stack
         path: |
           ${{ steps.setup-haskell-stack.outputs.stack-root }}
 
+    # On Windows, some of the stack state (e.g. copies of GHC) is stored,
+    # not in c:\sr, but in %LOCALAPPDATA%\Programs\stack
+    # (e.g. C:\Users\runneradmin\AppData\Local\Programs\stack)
+    - uses: actions/cache@v1
+      name: Cache ~/.stack
+      if: runner.os == 'windows'
+      with:
+        key: ${{ secrets.WINDOWS_CI_CACHE_DATE }}-${{ runner.os }}-${{ matrix.lts }}-stack-${{ hashFiles('stack-*yaml.lock') }}
+        restore-keys: |
+          ${{ secrets.WINDOWS_CI_CACHE_DATE }}-${{ runner.os }}-${{ matrix.lts }}-stack
+        path: |
+          ~\AppData\Local\Programs\stack
+          ${{ steps.setup-haskell-stack.outputs.stack-root }}
 
     # see https://github.com/phlummox/hup/issues/8
+    # On macOS, restoring cache may muck up executable permissions
     - name: Clear setup-exe-cache directory
       if: runner.os == 'macOS'
       run: rm -rf ${{ steps.setup-haskell-stack.outputs.stack-root }}/setup-exe-cache

--- a/hup.cabal
+++ b/hup.cabal
@@ -43,7 +43,7 @@ source-repository head
 Flag EnableWebTests
   Description: Enable tests that do a (pretty minimal) check by running an actual
     Warp web server. (Slower to build and run than other tests.)
-  Default:     False
+  Default:     True
   Manual:      True
 
 Flag ExtraGhcWarnings
@@ -171,20 +171,13 @@ test-suite hup-spec
     , hspec
     , hspec-core
     , QuickCheck
-    , simple
+    , scotty
     , temporary
+    , text
     , transformers
     , wai
     , wai-extra
-  if impl(ghc < 8.4.4)
-    build-depends:
-      -- simple-templates 0.9.0.0 has broken bounds.
-      -- (<https://github.com/alevy/simple/issues/25>)
-      -- It states bounds on base of "< 6",
-      -- but the code only seems to build with
-      -- base >= 4.11.1.0 / ghc >= 8.4.4.
-      simple-templates < 0.9.0.0
-
+    , mtl
   ghc-options:      -threaded
                     -rtsopts
                     -with-rtsopts=-N

--- a/src-hspec-test/Distribution/Hup/Upload/Test.hs
+++ b/src-hspec-test/Distribution/Hup/Upload/Test.hs
@@ -29,20 +29,17 @@ arbAuth =
 --
 -- Doesn't check the file/body, just metadata.
 
-{-
-- httpRoundTripsOK'
--   :: (HTTP.Client.Request -> IO Response)
--      -> Int -> Property
--}
+
+httpRoundTripsOK' :: (HTTP.Client.Request -> IO Response) -> Int -> Property
 httpRoundTripsOK' sendRequest port = 
   forAll arbUpload $ \upl ->
     forAll arbAuth $ \auth ->
       httpRoundTripsOK  sendRequest port upl auth
 
-{-
-httpRoundTripsOK :: (HTTP.Client.Request -> IO Response)
-                    -> Int -> Upload -> Maybe Auth -> Property
--}
+
+httpRoundTripsOK ::
+  (HTTP.Client.Request -> IO Response)
+  -> Int -> Upload -> Maybe Auth -> Property
 httpRoundTripsOK sendRequest port upl auth = 
       monadicIO $ do
         response <- run $ emptyFileRequest port upl auth
@@ -87,10 +84,9 @@ badUrlReturns' sendRequest port =
 -- | Given a bad url, the http library should return a 
 -- non-2XX status code, rather than throwing an exception.
 
-{-
-badUrlReturns :: (HTTP.Client.Request -> IO Response)
-                 -> Int -> Upload -> Maybe Auth -> Property
--}
+badUrlReturns ::
+  (HTTP.Client.Request -> IO Response)
+  -> Int -> Upload -> Maybe Auth -> Property
 badUrlReturns sendRequest port upl auth = 
   monadicIO $ do
     response <- run $ badRequest port upl auth


### PR DESCRIPTION
Switch over to Scotty from the `simple` web framework, which (a) is less used, and (b) seems to cause some compilation issues when compiling with cabal.