### PR TITLE
Update to use new haddock args

### DIFF
--- a/app/DocBuilding.hs
+++ b/app/DocBuilding.hs
@@ -120,8 +120,8 @@ cabalHaddock baseDir verbosityArgs haddockExtraArgs = do
                       then ["--haddock-option=--hyperlinked-source"]
                       else []
   run_ "cabal" $ ["haddock", "--builddir=" <> tt (buildDir baseDir),
-                  "--html-location=/package/$pkg-$version/docs",
-                  "--contents-location=/package/$pkg-$version"]
+                  "--haddock-html-location=/package/$pkg-$version/docs",
+                  "--haddock-contents-location=/package/$pkg-$version"]
                   ++ hyperlinkArgs ++ verbosityArgs
                   ++ haddockExtraArgs
 


### PR DESCRIPTION
Not completely sure which version of haddock this changed in, but it doesn't work for me now without it.

Maybe this should be done with some version qualification?